### PR TITLE
Workaround `welcome string` bug on Windows

### DIFF
--- a/examples/src/main/scala/org/parboiled2/examples/ABCParser.scala
+++ b/examples/src/main/scala/org/parboiled2/examples/ABCParser.scala
@@ -25,7 +25,7 @@ object ABCParser extends App {
 
   @tailrec
   def repl(): Unit =
-    readLine("---\nEnter expression for abc-parser > ") match {
+    readLine("---\nEnter expression for abc-parser >\n") match {
       case "" ⇒
       case line ⇒
         val parser = new ABCParser(line)

--- a/examples/src/main/scala/org/parboiled2/examples/Calculator1.scala
+++ b/examples/src/main/scala/org/parboiled2/examples/Calculator1.scala
@@ -25,7 +25,7 @@ object Calculator1 extends App {
 
   @tailrec
   def repl(): Unit =
-    readLine("---\nEnter calculator expression > ") match {
+    readLine("---\nEnter calculator expression >\n") match {
       case "" =>
       case line =>
         val parser = new Calculator1(line)

--- a/examples/src/main/scala/org/parboiled2/examples/Calculator2.scala
+++ b/examples/src/main/scala/org/parboiled2/examples/Calculator2.scala
@@ -25,7 +25,7 @@ object Calculator2 extends App {
 
   @tailrec
   def repl(): Unit =
-    readLine("---\nEnter calculator expression > ") match {
+    readLine("---\nEnter calculator expression >\n") match {
       case "" =>
       case line =>
         val parser = new Calculator2(line)


### PR DESCRIPTION
`java.lang.System.out` that `readLine` depends on to write welcome string does not flush whole string on Windows platform. So, the workaround forces to flush it all.
