### PR TITLE
= Workaround for `prompt` string bug on Windows

### DIFF
--- a/examples/src/main/scala/org/parboiled2/examples/ABCParser.scala
+++ b/examples/src/main/scala/org/parboiled2/examples/ABCParser.scala
@@ -24,8 +24,12 @@ object ABCParser extends App {
   repl()
 
   @tailrec
-  def repl(): Unit =
-    readLine("---\nEnter expression for abc-parser > ") match {
+  def repl(): Unit = {
+    // TODO: Replace next three lines with `scala.Predef.readLine(text: String, args: Any*)`
+    // once BUG https://issues.scala-lang.org/browse/SI-8167 is fixed
+    print("---\nEnter expression for abc-parser > ")
+    Console.out.flush()
+    readLine() match {
       case "" ⇒
       case line ⇒
         val parser = new ABCParser(line)
@@ -36,6 +40,7 @@ object ABCParser extends App {
         }
         repl()
     }
+  }
 }
 
 /**

--- a/examples/src/main/scala/org/parboiled2/examples/Calculator1.scala
+++ b/examples/src/main/scala/org/parboiled2/examples/Calculator1.scala
@@ -24,8 +24,12 @@ object Calculator1 extends App {
   repl()
 
   @tailrec
-  def repl(): Unit =
-    readLine("---\nEnter calculator expression > ") match {
+  def repl(): Unit = {
+    // TODO: Replace next three lines with `scala.Predef.readLine(text: String, args: Any*)`
+    // once BUG https://issues.scala-lang.org/browse/SI-8167 is fixed
+    print("---\nEnter calculator expression > ")
+    Console.out.flush()
+    readLine() match {
       case "" =>
       case line =>
         val parser = new Calculator1(line)
@@ -36,6 +40,7 @@ object Calculator1 extends App {
         }
         repl()
     }
+  }
 }
 
 /**

--- a/examples/src/main/scala/org/parboiled2/examples/Calculator2.scala
+++ b/examples/src/main/scala/org/parboiled2/examples/Calculator2.scala
@@ -24,8 +24,12 @@ object Calculator2 extends App {
   repl()
 
   @tailrec
-  def repl(): Unit =
-    readLine("---\nEnter calculator expression > ") match {
+  def repl(): Unit = {
+    // TODO: Replace next three lines with `scala.Predef.readLine(text: String, args: Any*)`
+    // once BUG https://issues.scala-lang.org/browse/SI-8167 is fixed
+    print("---\nEnter calculator expression > ")
+    Console.out.flush()
+    readLine() match {
       case "" =>
       case line =>
         val parser = new Calculator2(line)
@@ -36,6 +40,7 @@ object Calculator2 extends App {
         }
         repl()
     }
+  }
 
   def eval(expr: Expr): Int =
     expr match {


### PR DESCRIPTION
Bug: https://issues.scala-lang.org/browse/SI-8167

Review fixes for https://github.com/sirthias/parboiled2/pull/54

`scala.Console.out` that `readLine` depends on to write welcome string does not flush whole string on Windows platform. A workaround forces to flush `scala.Console.out` manually
