### PR TITLE
Add full paths to org.parboiled2 types in qqotes

### DIFF
--- a/parboiled-core/src/test/scala/org/parboiled2/nested/ExtendedParserSpec.scala
+++ b/parboiled-core/src/test/scala/org/parboiled2/nested/ExtendedParserSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2009-2013 Mathias Doenitz, Alexander Myltsev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.parboiled2.nested
+
+import scala.util.Success
+import org.specs2.mutable.Specification
+
+/**
+ * Tests if a parser will compile when org.parboiled2._ is not explicitly imported
+ */
+
+class ExtendedParserSpec extends Specification {
+
+  class FooParser(input: String) extends AbstractParser(input) {
+    def Go = rule {
+      foo ~ EOI
+    }
+  }
+
+  "Parsers in files that dont explicitly import org.parboiled2._" should {
+    "compile" in {
+      new FooParser("foo123").Go.run() should_== Success("foo123")
+    }
+  }
+
+}


### PR DESCRIPTION
When building up parsers, often it may not be necessary to import the entire org.parboiled2 package. However, many of the names used in quasiquotes in the OpTreeContext trait currently rely on that path being available to resolve things like Parser and Rule, and will fail with the usual lack of information if they are not imported. 
### This pull request adds:
- The whole path to the relevant quasiquotes
- A test which demonstrates the behavior
