### PR TITLE
Fix failure of named arguments in push actions

### DIFF
--- a/parboiled-core/src/main/scala/org/parboiled2/support/OpTreeContext.scala
+++ b/parboiled-core/src/main/scala/org/parboiled2/support/OpTreeContext.scala
@@ -469,7 +469,7 @@ trait OpTreeContext[OpTreeCtx <: Parser.ParserContext] {
       block(hlTree match {
         case q"support.this.HListable.fromUnit"       ⇒ argTree
         case q"support.this.HListable.fromHList[$t]"  ⇒ q"valueStack.pushAll(${c.resetLocalAttrs(argTree)})"
-        case q"support.this.HListable.fromAnyRef[$t]" ⇒ q"valueStack.push($argTree)"
+        case q"support.this.HListable.fromAnyRef[$t]" ⇒ q"valueStack.push(${c.resetLocalAttrs(argTree)})"
         case x                                        ⇒ c.abort(hlTree.pos, "Unexpected HListable: " + show(x))
       }, c.literalTrue.tree)
   }

--- a/parboiled-core/src/test/scala/org/parboiled2/PushResetSpec.scala
+++ b/parboiled-core/src/test/scala/org/parboiled2/PushResetSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2009-2013 Mathias Doenitz, Alexander Myltsev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.parboiled2
+
+import org.specs2.mutable._
+import scala.util.Success
+
+class PushResetSpec extends Specification {
+
+  case class A(a: Int = 0, b: Int = 1)
+
+  class Foo(val input: ParserInput) extends Parser {
+    def Foo: Rule1[A] = rule {
+      "foo" ~ push(A(b = 2))
+    }
+  }
+
+  "push action" should {
+    "handle default arguments" in {
+      new Foo("foo").Foo.run() should_== Success(A(0, 2))
+    }
+  }
+}


### PR DESCRIPTION
For some reason, which may due to no fault of parboiled2 and rather a macro bug, when trying to push to the stack a value using named and default args, a compiler error occurs. 

The problem may be more widespread than this.
### This Pull Request Adds:
- A test demonstrating the problem
- Calls resetLocalAttrs on the appropriate tree which seems to fix the problem
