### PR TITLE
= Fixes case when Range is defined with val

### DIFF
--- a/parboiled-core/src/test/scala/org/parboiled2/CombinatorSpec.scala
+++ b/parboiled-core/src/test/scala/org/parboiled2/CombinatorSpec.scala
@@ -219,6 +219,15 @@ class CombinatorSpec extends TestParserSpec {
       "xxxxx" must beMismatched
     }
 
+    "`(2 to max).times(Rule0)` modifier where `max` is 4" in new TestParser0 {
+      val max = 4
+      val targetRule = rule { (2 to max).times("x") ~ EOI }
+      "xx" must beMatched
+      "xxx" must beMatched
+      "xxxx" must beMatched
+      "xxxxx" must beMismatched
+    }
+
     "`(2 to 4).times(Rule0).separatedBy('|')` modifier" in new TestParser0 {
       val targetRule = rule { (2 to 4).times("x").separatedBy('|') ~ EOI }
       "xx" must beMismatched


### PR DESCRIPTION
Closes: https://github.com/sirthias/parboiled2/issues/150

Also note that code as follows is also valid now: 

```scala
(5 to 3).times(SomeRule)
```

It expands to: `(min(3, 5), max(3, 5)).times(SomeRule)`.