### PR TITLE
OSGi manifests via sbt-osgi plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import scalariform.formatter.preferences._
 import scala.xml.transform._
 import scala.xml.{Node => XNode, NodeSeq}
+import com.typesafe.sbt.osgi.SbtOsgi._
 
 val commonSettings = Seq(
   version := "2.2.0-SNAPSHOT",
@@ -34,6 +35,10 @@ val formattingSettings = scalariformSettings ++ Seq(
     .setPreference(AlignSingleLineCaseStatements, true)
     .setPreference(DoubleIndentClassDeclaration, true)
     .setPreference(PreserveDanglingCloseParenthesis, true))
+
+val pbOsgiSettings = osgiSettings ++ Seq(
+  packageBin in Runtime <<= OsgiKeys.bundle,
+  OsgiKeys.exportPackage := Seq("org.parboiled2;-split-package:=merge-first", "org.parboiled2.*;-split-package:=merge-first"))
 
 val publishingSettings = Seq(
   publishMavenStyle := true,
@@ -103,6 +108,7 @@ lazy val scalaParser = project
   .settings(commonSettings: _*)
   .settings(noPublishingSettings: _*)
   .settings(libraryDependencies ++= Seq(shapeless, specs2Core))
+  .settings(pbOsgiSettings: _*)
 
 lazy val parboiled = project
   .dependsOn(parboiledCore)
@@ -123,6 +129,7 @@ lazy val parboiled = project
       new RuleTransformer(filter).transform(_).head
     }
   )
+  .settings(pbOsgiSettings: _*)  
 
 lazy val generateActionOps = taskKey[Seq[File]]("Generates the ActionOps boilerplate source file")
 
@@ -134,3 +141,4 @@ lazy val parboiledCore = project.in(file("parboiled-core"))
     libraryDependencies ++= Seq(scalaReflect, shapeless, specs2Core, specs2ScalaCheck),
     generateActionOps := ActionOpsBoilerplate((sourceManaged in Compile).value, streams.value),
     (sourceGenerators in Compile) += generateActionOps.taskValue)
+  .settings(pbOsgiSettings: _*)    

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.1")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.7.0")
+


### PR DESCRIPTION
Hi. 

Could you merge this pull request just to enable OSGi manifests for your library? 

Also could you be so kind to OSGify parbolied v1, just to enable Spray to work in OSGi containers? Here is my pull request for parboiled v1: https://github.com/sirthias/parboiled/pull/92