### PR TITLE
Added SBT-OSGi to allow Parboiled2 to generate an OSGi valid JAR artifact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,6 +108,11 @@ lazy val scalaParser = project
   .settings(noPublishingSettings: _*)
   .settings(libraryDependencies ++= Seq(shapeless, specs2Core))
 
+lazy val parboiledOsgiSettings = osgiSettings ++ Seq(
+  OsgiKeys.exportPackage := Seq("org.parboiled2.*;version=${Bundle-Version}"),
+  OsgiKeys.privatePackage := Seq()
+)
+
 lazy val parboiled = crossProject.crossType(CrossType.Pure)
   .dependsOn(parboiledCore)
   .settings(commonSettings: _*)
@@ -133,7 +138,8 @@ lazy val parboiled = crossProject.crossType(CrossType.Pure)
       }
       new RuleTransformer(filter).transform(_).head
     }
-  )
+  ).
+  enablePlugins(SbtOsgi).settings(parboiledOsgiSettings:_*)
 
 lazy val parboiledJVM = parboiled.jvm
 lazy val parboiledJS = parboiled.js

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,5 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.20")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.8.0")


### PR DESCRIPTION
Added SBT-OSGi to allow Parboiled2 to generate an OSGi valid JAR artifact on publish or publishLocal, this allowed Parboiled2 to be used within an OSGi environment. Look at the file MANIFEST.MF inside the artifact JAR (result of publishLocal) before and after this change was added to see the changes. The change is that there are import and export packages defined there which allows OSGi to work out what imports and exports the JAR defines.