### PR TITLE
Select the longest matching key in matchMap

### DIFF
--- a/parboiled-core/src/main/scala/org/parboiled2/Parser.scala
+++ b/parboiled-core/src/main/scala/org/parboiled2/Parser.scala
@@ -449,7 +449,7 @@ abstract class Parser(initialValueStackSize: Int = 16,
    * THIS IS NOT PUBLIC API and might become hidden in future. Use only if you know what you are doing!
    */
   def __matchMap(m: Map[String, Any]): Boolean = {
-    val keys = m.keysIterator
+    val keys = m.keys.toSeq.sortBy(-_.length).iterator
     while (keys.hasNext) {
       val mark = __saveState
       val key = keys.next()
@@ -465,7 +465,7 @@ abstract class Parser(initialValueStackSize: Int = 16,
    * THIS IS NOT PUBLIC API and might become hidden in future. Use only if you know what you are doing!
    */
   def __matchMapWrapped(m: Map[String, Any]): Boolean = {
-    val keys = m.keysIterator
+    val keys = m.keys.toSeq.sortBy(-_.length).iterator
     val start = _cursor
     try {
       while (keys.hasNext) {

--- a/parboiled-core/src/main/scala/org/parboiled2/Parser.scala
+++ b/parboiled-core/src/main/scala/org/parboiled2/Parser.scala
@@ -18,6 +18,7 @@ package org.parboiled2
 
 import scala.annotation.tailrec
 import scala.collection.immutable.VectorBuilder
+import scala.collection.mutable
 import scala.util.{ Failure, Success, Try }
 import scala.util.control.{ NonFatal, NoStackTrace }
 import shapeless._
@@ -449,10 +450,11 @@ abstract class Parser(initialValueStackSize: Int = 16,
    * THIS IS NOT PUBLIC API and might become hidden in future. Use only if you know what you are doing!
    */
   def __matchMap(m: Map[String, Any]): Boolean = {
-    val keys = m.keys.toSeq.sortBy(-_.length).iterator
-    while (keys.hasNext) {
+    val prioritizedKeys = new mutable.PriorityQueue[String]()(Ordering.by(_.length))
+    prioritizedKeys ++= m.keysIterator
+    while (prioritizedKeys.nonEmpty) {
       val mark = __saveState
-      val key = keys.next()
+      val key = prioritizedKeys.dequeue()
       if (__matchString(key)) {
         __push(m(key))
         return true
@@ -465,12 +467,13 @@ abstract class Parser(initialValueStackSize: Int = 16,
    * THIS IS NOT PUBLIC API and might become hidden in future. Use only if you know what you are doing!
    */
   def __matchMapWrapped(m: Map[String, Any]): Boolean = {
-    val keys = m.keys.toSeq.sortBy(-_.length).iterator
+    val prioritizedKeys = new mutable.PriorityQueue[String]()(Ordering.by(_.length))
+    prioritizedKeys ++= m.keysIterator
     val start = _cursor
     try {
-      while (keys.hasNext) {
+      while (prioritizedKeys.nonEmpty) {
         val mark = __saveState
-        val key = keys.next()
+        val key = prioritizedKeys.dequeue()
         if (__matchStringWrapped(key)) {
           __push(m(key))
           return true

--- a/parboiled-core/src/test/scala/org/parboiled2/BasicSpec.scala
+++ b/parboiled-core/src/test/scala/org/parboiled2/BasicSpec.scala
@@ -170,8 +170,8 @@ class BasicSpec extends TestParserSpec {
     }
 
     "Map[String, T] with keys that prefix each other" in new TestParser1[Int] {
-      val colors = Map("a" -> 1, "ab" -> 2, "abc" -> 3, "abcd" -> 4, "abcde" -> 5, "abcdef" -> 6)
-      def targetRule = rule { colors ~ EOI }
+      val map = Map("a" -> 1, "ab" -> 2, "abc" -> 3, "abcd" -> 4, "abcde" -> 5, "abcdef" -> 6)
+      def targetRule = rule { map ~ EOI }
       "a" must beMatchedWith(1)
       "ab" must beMatchedWith(2)
       "abc" must beMatchedWith(3)

--- a/parboiled-core/src/test/scala/org/parboiled2/BasicSpec.scala
+++ b/parboiled-core/src/test/scala/org/parboiled2/BasicSpec.scala
@@ -168,6 +168,17 @@ class BasicSpec extends TestParserSpec {
       "blue" must beMatchedWith(3)
       "black" must beMismatched
     }
+
+    "Map[String, T] with keys that prefix each other" in new TestParser1[Int] {
+      val colors = Map("a" -> 1, "ab" -> 2, "abc" -> 3, "abcd" -> 4, "abcde" -> 5, "abcdef" -> 6)
+      def targetRule = rule { colors ~ EOI }
+      "a" must beMatchedWith(1)
+      "ab" must beMatchedWith(2)
+      "abc" must beMatchedWith(3)
+      "abcd" must beMatchedWith(4)
+      "abcde" must beMatchedWith(5)
+      "abcdef" must beMatchedWith(6)
+    }
   }
 
   "The Parser" should {


### PR DESCRIPTION
Fixes #136

By checking keys from longest to shortest, we ensure that we always
select the longest matching key.

This fix requires sorting the keys each time the rule is invoked. If
#115 gets implemented, this could be improved to make use of it instead.