### PR TITLE
fix deprecation warning. Left#a deprecated

### DIFF
--- a/parboiled-core/src/main/scala/org/parboiled2/support/OpTreeContext.scala
+++ b/parboiled-core/src/main/scala/org/parboiled2/support/OpTreeContext.scala
@@ -602,7 +602,7 @@ trait OpTreeContext[OpTreeCtx <: ParserMacros.ParserContext] {
         case Left(_)  ⇒ super.render(wrapped)
         case Right(x) ⇒ q"$x ne null"
       }
-    def renderInner(wrapped: Boolean) = call.asInstanceOf[Left[OpTree, Tree]].a.render(wrapped)
+    def renderInner(wrapped: Boolean) = call.left.get.render(wrapped)
   }
 
   def CharRange(lowerTree: Tree, upperTree: Tree): CharacterRange = {


### PR DESCRIPTION
https://github.com/scala/scala/blob/v2.12.6/src/library/scala/util/Either.scala#L429