### PR TITLE
2.13.0-RC1: new diverging expansion in DSLTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk: oraclejdk8
 scala:
 - 2.11.12
 - 2.12.8
-- 2.13.0-M5
+- 2.13.0-RC1
 script:
 - sbt "++ ${TRAVIS_SCALA_VERSION}" test "scalaParser/testOnly scalaparser.SnippetSpec"
 matrix:

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ import sbtcrossproject.CrossPlugin.autoImport._
 val commonSettings = Seq(
   version := "2.1.5",
   scalaVersion := "2.12.8",
-  crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0-M5"),
+  crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0-RC1"),
   organization := "org.parboiled",
   homepage := Some(new URL("http://parboiled.org")),
   description := "Fast and elegant PEG parsing in Scala - lightweight, easy-to-use, powerful",
@@ -82,7 +82,7 @@ val utestSettings = Seq(
 
 def scalaReflect(v: String) = "org.scala-lang"  %  "scala-reflect"     % v       % "provided"
 val shapeless               = Def.setting("com.chuusai"       %%% "shapeless"         % "2.3.3" % "compile")
-val utest                   = Def.setting("com.lihaoyi"       %%% "utest"             % "0.6.6" % Test)
+val utest                   = Def.setting("com.lihaoyi"       %%% "utest"             % "0.6.7" % Test)
 val scalaCheck              = Def.setting("org.scalacheck"    %%% "scalacheck"        % "1.14.0" % Test)
 // since ScalaCheck native is not available from the original authors @lolgab made a release
 // see https://github.com/rickynils/scalacheck/issues/396#issuecomment-467782592

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.5")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.27")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.3")
 


### PR DESCRIPTION
parboiled2 tests do not compile on Scala 2.13.0-RC1.  Pushing as a draft PR instead of an issue so there's something to build from:

```
[error] /home/ross/src/parboiled2/parboiled-core/src/test/scala/org/parboiled2/DSLTest.scala:31: diverging implicit expansion for type org.parboiled2.support.ActionOps.SJoin[shapeless.HNil,Int :: Boolean :: String :: Int :: Boolean :: Int :: Boolean :: shapeless.HNil,Array[Char]]
[error] starting with method iter2 in object Aux
[error]   def OpsTest1 = rule { ComplexRule ~> (_.toCharArray) }
[error]                                     ^
[error] /home/ross/src/parboiled2/parboiled-core/src/test/scala/org/parboiled2/DSLTest.scala:34: diverging implicit expansion for type org.parboiled2.support.Join.Aux[shapeless.HNil,shapeless.HNil,shapeless.HNil,Int :: shapeless.HNil,Int :: Boolean :: Int :: String :: Boolean :: Int :: shapeless.HNil,shapeless.HNil,Out]
[error] starting with method terminate in object Aux
[error]   def OpsTest2 = rule { ComplexRule ~> ((_, s) => s.length) ~> (_ + _) }
[error]                                     ^
```