### PR TITLE
 Fix Base64Parsing for blocks and extra characters

### DIFF
--- a/parboiled/src/test/scala/org/parboiled2/Base64ParsingSpec.scala
+++ b/parboiled/src/test/scala/org/parboiled2/Base64ParsingSpec.scala
@@ -50,7 +50,7 @@ object Base64ParsingSpec extends TestSuite {
 
   def test(ruleName: String, base64: Base64): Unit =
     (1 to 100).foreach { x =>
-      val string  = randomChars.take(x).toString()
+      val string  = randomChars.take(x).mkString("")
       val encoded = base64.encodeToString(string getBytes UTF8, lineSep = false)
       val parser = new TestParser(encoded) with DynamicRuleHandler[TestParser, Array[Byte] :: HNil] {
         type Result = String


### PR DESCRIPTION
@adriaanm discovered that Base64 parsing wasn't being exercised as expected: https://github.com/http4s/parboiled2/pull/10

When corrected, the block tests failed.  This is fixed, though a deprecation of the existing rule was necessary to maintain binary compatibility.  I also added an `EOI` to preclude trailing junk.
