### PR TITLE
retain OpTreeContext structure for consistency with scala-2 

### DIFF
--- a/parboiled-core/src/main/scala-3/org/parboiled2/ParserMacros.scala
+++ b/parboiled-core/src/main/scala-3/org/parboiled2/ParserMacros.scala
@@ -18,17 +18,17 @@ package org.parboiled2
 
 import org.parboiled2.support.hlist.HList
 
-private[parboiled2] trait ParserMacroMethods {
+private[parboiled2] trait ParserMacroMethods { parser: Parser =>
 
   /** Converts a compile-time only rule definition into the corresponding rule method implementation.
     */
-  inline def rule[I <: HList, O <: HList](inline r: Rule[I, O]): Rule[I, O] = ${ ParserMacros.ruleImpl('r) }
+  inline def rule[I <: HList, O <: HList](inline r: Rule[I, O]): Rule[I, O] = ${ ParserMacros.ruleImpl('parser, 'r) }
 
   /** Converts a compile-time only rule definition into the corresponding rule method implementation
     * with an explicitly given name.
     */
   inline def namedRule[I <: HList, O <: HList](name: String)(inline r: Rule[I, O]): Rule[I, O] = ${
-    ParserMacros.nameRuleImpl('name)('r)
+    ParserMacros.nameRuleImpl('parser, 'name, 'r)
   }
 
 }
@@ -42,85 +42,39 @@ private[parboiled2] trait RuleRunnable {
   }
 }
 
-object ParserMacros {
-  import scala.quoted._
-  import scala.compiletime._
-
-  def ruleImpl[I <: HList: Type, O <: HList: Type](r: Expr[Rule[I, O]])(using Quotes): Expr[Rule[I, O]] =
-    nameRuleImpl(Expr("todo"))(r)
-
-  def nameRuleImpl[I <: HList: Type, O <: HList: Type](
-      name: Expr[String]
-  )(r: Expr[Rule[I, O]])(using Quotes): Expr[Rule[I, O]] = {
-    import quotes.reflect.*
-
-    def opTreeF(rule: Expr[Rule[I, O]]): OpTree = rule match {
-      case '{
-            (${ lhs }: Rule[I, O])
-              .~((${ rhs }: Rule[I, O]))($c, $d)
-          } =>
-        Sequence(Seq(opTreeF(lhs), opTreeF(rhs)))
-      case '{ ($p: Parser).ch($c) }                 => CharMatch(p, c)
-      case '{ ($p: Parser).str($s) }                => StringMatch(p, s)
-      case '{ ($p: Parser).ignoreCase($c: Char) }   => IgnoreCaseChar(p, c)
-      case '{ ($p: Parser).ignoreCase($s: String) } => IgnoreCaseString(p, s)
-      case '{ ($p: Parser).predicate($pr) }         => CharPredicateMatch(p, pr)
-      case '{ ($p: Parser).anyOf($s) }              => AnyOf(p, s)
-      case '{ ($p: Parser).noneOf($s) }             => NoneOf(p, s)
-      case '{ ($p: Parser).ANY }                    => ANY(p)
-      case _                                        => reportError(s"Invalid rule definition: '${r.show}';", r)
-    }
-
-    val opTree: OpTree = opTreeF(r)
-
-    val parser = opTree.parser
-    '{
-      def wrapped: Boolean = ${ opTree.render(wrapped = true) }
-      val matched =
-        if ($parser.__inErrorAnalysis) wrapped
-        else ${ opTree.render(wrapped = false) }
-      if (matched) org.parboiled2.Rule.asInstanceOf[Rule[I, O]] else null
-    }
-  }
-
-  private def reportError(error: String, expr: Expr[Any])(using quotes: Quotes): Nothing = {
-    quotes.reflect.report.error(error, expr)
-    throw new Exception(error)
-  }
-
+import scala.quoted._
+class OpTreeContext(parser: Expr[Parser])(using Quotes) {
   sealed trait OpTree {
-    def parser: Expr[Parser]
-    def render(wrapped: Boolean)(using Quotes): Expr[Boolean]
-  }
-
-  case class Sequence(ops: Seq[OpTree]) extends OpTree {
-    val parser = ops.head.parser
-    override def render(wrapped: Boolean)(using Quotes): Expr[Boolean] =
-      ops
-        .map(_.render(wrapped))
-        .reduceLeft((l, r) => '{ val ll = $l; if (ll) $r else false })
+    def render(wrapped: Boolean): Expr[Boolean]
   }
 
   sealed abstract class TerminalOpTree extends OpTree {
-    def bubbleUp(using quotes: Quotes): Expr[Nothing] = '{ $parser.__bubbleUp($ruleTraceTerminal) }
-    def ruleTraceTerminal(using quotes: Quotes): Expr[RuleTrace.Terminal]
+    def bubbleUp: Expr[Nothing] = '{ $parser.__bubbleUp($ruleTraceTerminal) }
+    def ruleTraceTerminal: Expr[RuleTrace.Terminal]
 
-    final def render(wrapped: Boolean)(using quotes: Quotes): Expr[Boolean] =
+    final def render(wrapped: Boolean): Expr[Boolean] =
       if (wrapped) '{
         try ${ renderInner(wrapped) } catch { case org.parboiled2.Parser.StartTracingException => $bubbleUp }
       }
       else renderInner(wrapped)
 
-    protected def renderInner(wrapped: Boolean)(using Quotes): Expr[Boolean]
+    protected def renderInner(wrapped: Boolean): Expr[Boolean]
   }
 
   sealed abstract class PotentiallyNamedTerminalOpTree extends TerminalOpTree {
     // TODO
   }
 
-  case class CharMatch(parser: Expr[Parser], charTree: Expr[Char]) extends TerminalOpTree {
-    def ruleTraceTerminal(using quotes: Quotes) = '{ org.parboiled2.RuleTrace.CharMatch($charTree) }
-    override def renderInner(wrapped: Boolean)(using Quotes): Expr[Boolean] = {
+  case class Sequence(ops: Seq[OpTree]) extends OpTree {
+    override def render(wrapped: Boolean): Expr[Boolean] =
+      ops
+        .map(_.render(wrapped))
+        .reduceLeft((l, r) => '{ val ll = $l; if (ll) $r else false })
+  }
+
+  case class CharMatch(charTree: Expr[Char]) extends TerminalOpTree {
+    def ruleTraceTerminal = '{ org.parboiled2.RuleTrace.CharMatch($charTree) }
+    override def renderInner(wrapped: Boolean): Expr[Boolean] = {
       val unwrappedTree = '{
         $parser.cursorChar == $charTree && $parser.__advance()
       }
@@ -129,10 +83,10 @@ object ParserMacros {
     }
   }
 
-  case class StringMatch(parser: Expr[Parser], stringTree: Expr[String]) extends OpTree {
+  case class StringMatch(stringTree: Expr[String]) extends OpTree {
     final private val autoExpandMaxStringLength = 8
 
-    override def render(wrapped: Boolean)(using Quotes): Expr[Boolean] =
+    override def render(wrapped: Boolean): Expr[Boolean] =
       // TODO: add optimization for literal constant
       // def unrollUnwrapped(s: String, ix: Int = 0): Tree =
       //   if (ix < s.length) q"""
@@ -168,11 +122,10 @@ object ParserMacros {
       if (wrapped) '{ $parser.__matchStringWrapped($stringTree) }
       else '{ $parser.__matchString($stringTree) }
   }
+  case class IgnoreCaseChar(charTree: Expr[Char]) extends TerminalOpTree {
+    def ruleTraceTerminal = '{ org.parboiled2.RuleTrace.IgnoreCaseChar($charTree) }
 
-  case class IgnoreCaseChar(parser: Expr[Parser], charTree: Expr[Char]) extends TerminalOpTree {
-    def ruleTraceTerminal(using quotes: Quotes) = '{ org.parboiled2.RuleTrace.IgnoreCaseChar($charTree) }
-
-    override def renderInner(wrapped: Boolean)(using Quotes): Expr[Boolean] = {
+    override def renderInner(wrapped: Boolean): Expr[Boolean] = {
       val unwrappedTree = '{
         _root_.java.lang.Character.toLowerCase($parser.cursorChar) == $charTree && $parser.__advance()
       }
@@ -181,10 +134,10 @@ object ParserMacros {
     }
   }
 
-  case class IgnoreCaseString(parser: Expr[Parser], stringTree: Expr[String]) extends OpTree {
+  case class IgnoreCaseString(stringTree: Expr[String]) extends OpTree {
     final private val autoExpandMaxStringLength = 8
 
-    override def render(wrapped: Boolean)(using Quotes): Expr[Boolean] =
+    override def render(wrapped: Boolean): Expr[Boolean] =
       // TODO: optimize litera constant
       // def unrollUnwrapped(s: String, ix: Int = 0): Tree =
       //   if (ix < s.length) q"""
@@ -221,44 +174,92 @@ object ParserMacros {
       else '{ $parser.__matchIgnoreCaseString($stringTree) }
   }
 
-  case class CharPredicateMatch(parser: Expr[Parser], predicateTree: Expr[CharPredicate])
-      extends PotentiallyNamedTerminalOpTree {
-    def ruleTraceTerminal(using quotes: Quotes) = '{ org.parboiled2.RuleTrace.CharPredicateMatch($predicateTree) }
+  case class CharPredicateMatch(predicateTree: Expr[CharPredicate]) extends PotentiallyNamedTerminalOpTree {
+    def ruleTraceTerminal = '{ org.parboiled2.RuleTrace.CharPredicateMatch($predicateTree) }
 
-    override def renderInner(wrapped: Boolean)(using Quotes): Expr[Boolean] = {
+    override def renderInner(wrapped: Boolean): Expr[Boolean] = {
       val unwrappedTree = '{ $predicateTree($parser.cursorChar) && $parser.__advance() }
       if (wrapped) '{ $unwrappedTree && $parser.__updateMaxCursor() || $parser.__registerMismatch() }
       else unwrappedTree
     }
   }
 
-  case class AnyOf(parser: Expr[Parser], stringTree: Expr[String]) extends TerminalOpTree {
-    def ruleTraceTerminal(using quotes: Quotes) = '{ org.parboiled2.RuleTrace.AnyOf($stringTree) }
+  case class AnyOf(stringTree: Expr[String]) extends TerminalOpTree {
+    def ruleTraceTerminal = '{ org.parboiled2.RuleTrace.AnyOf($stringTree) }
 
-    override def renderInner(wrapped: Boolean)(using Quotes): Expr[Boolean] = {
+    override def renderInner(wrapped: Boolean): Expr[Boolean] = {
       val unwrappedTree = '{ $parser.__matchAnyOf($stringTree) }
       if (wrapped) '{ $unwrappedTree && $parser.__updateMaxCursor() || $parser.__registerMismatch() }
       else unwrappedTree
     }
   }
 
-  case class NoneOf(parser: Expr[Parser], stringTree: Expr[String]) extends TerminalOpTree {
-    def ruleTraceTerminal(using quotes: Quotes) = '{ org.parboiled2.RuleTrace.NoneOf($stringTree) }
+  case class NoneOf(stringTree: Expr[String]) extends TerminalOpTree {
+    def ruleTraceTerminal = '{ org.parboiled2.RuleTrace.NoneOf($stringTree) }
 
-    override def renderInner(wrapped: Boolean)(using Quotes): Expr[Boolean] = {
+    override def renderInner(wrapped: Boolean): Expr[Boolean] = {
       val unwrappedTree = '{ $parser.__matchNoneOf($stringTree) }
       if (wrapped) '{ $unwrappedTree && $parser.__updateMaxCursor() || $parser.__registerMismatch() }
       else unwrappedTree
     }
   }
 
-  case class ANY(parser: Expr[Parser]) extends TerminalOpTree {
-    def ruleTraceTerminal(using quotes: Quotes) = '{ org.parboiled2.RuleTrace.ANY }
+  case object ANY extends TerminalOpTree {
+    def ruleTraceTerminal = '{ org.parboiled2.RuleTrace.ANY }
 
-    override def renderInner(wrapped: Boolean)(using Quotes): Expr[Boolean] = {
+    override def renderInner(wrapped: Boolean): Expr[Boolean] = {
       val unwrappedTree = '{ $parser.cursorChar != EOI && $parser.__advance() }
       if (wrapped) '{ $unwrappedTree && $parser.__updateMaxCursor() || $parser.__registerMismatch() }
       else unwrappedTree
+    }
+  }
+
+  def deconstruct[I <: HList: Type, O <: HList: Type](rule: Expr[Rule[I, O]]): OpTree = rule match {
+    case '{
+          (${ lhs }: Rule[I, O])
+            .~((${ rhs }: Rule[I, O]))($c, $d)
+        } =>
+      Sequence(Seq(deconstruct(lhs), deconstruct(rhs)))
+    case '{ ($p: Parser).ch($c) }                 => CharMatch(c)
+    case '{ ($p: Parser).str($s) }                => StringMatch(s)
+    case '{ ($p: Parser).ignoreCase($c: Char) }   => IgnoreCaseChar(c)
+    case '{ ($p: Parser).ignoreCase($s: String) } => IgnoreCaseString(s)
+    case '{ ($p: Parser).predicate($pr) }         => CharPredicateMatch(pr)
+    case '{ ($p: Parser).anyOf($s) }              => AnyOf(s)
+    case '{ ($p: Parser).noneOf($s) }             => NoneOf(s)
+    case '{ ($p: Parser).ANY }                    => ANY
+    case _                                        => reportError(s"Invalid rule definition: '${rule.show}';", rule)
+  }
+
+  private def reportError(error: String, expr: Expr[Any]): Nothing = {
+    quotes.reflect.report.error(error, expr)
+    throw new Exception(error)
+  }
+}
+
+object ParserMacros {
+  import scala.quoted._
+  import scala.compiletime._
+
+  def ruleImpl[I <: HList: Type, O <: HList: Type](parser: Expr[Parser], r: Expr[Rule[I, O]])(using
+      Quotes
+  ): Expr[Rule[I, O]] =
+    nameRuleImpl(parser, Expr("todo"), r)
+
+  def nameRuleImpl[I <: HList: Type, O <: HList: Type](parser: Expr[Parser], name: Expr[String], r: Expr[Rule[I, O]])(
+      using Quotes
+  ): Expr[Rule[I, O]] = {
+    import quotes.reflect.*
+
+    val ctx    = new OpTreeContext(parser)
+    val opTree = ctx.deconstruct(r)
+
+    '{
+      def wrapped: Boolean = ${ opTree.render(wrapped = true) }
+      val matched =
+        if ($parser.__inErrorAnalysis) wrapped
+        else ${ opTree.render(wrapped = false) }
+      if (matched) org.parboiled2.Rule.asInstanceOf[Rule[I, O]] else null
     }
   }
 }


### PR DESCRIPTION
And also because it simplifies the AST construction.

WDYT, @yanns? Would be good to merge this first otherwise, we'll get lots of conflicts.