### PR TITLE
fix ReductionTypeSpec

### DIFF
--- a/parboiled-core/src/test/scala/org/parboiled2/ReductionTypeSpec.scala
+++ b/parboiled-core/src/test/scala/org/parboiled2/ReductionTypeSpec.scala
@@ -26,12 +26,12 @@ object ReductionTypeSpec extends TestSuite {
   case class Foo2(lhs: Foo, rhs: Foo) extends Foo
 
   class FooParser(val input: ParserInput) extends Parser {
-    def OneOrMoreExpr  = rule(foo1 ~ oneOrMore(foo1 ~> Foo2))
-    def ZeroOrMoreExpr = rule(foo1 ~ zeroOrMore(foo1 ~> Foo2))
-    def OptionalExpr   = rule(foo1 ~ optional(foo1 ~> Foo2))
-    def TimesExpr      = rule(foo1 ~ 2.times(foo1 ~> Foo2))
+    def OneOrMoreExpr: Rule1[Foo2] = rule(foo1 ~ oneOrMore(foo1 ~> Foo2.apply))
+    def ZeroOrMoreExpr: Rule1[Foo] = rule(foo1 ~ zeroOrMore(foo1 ~> Foo2.apply))
+    def OptionalExpr: Rule1[Foo]   = rule(foo1 ~ optional(foo1 ~> Foo2.apply))
+    def TimesExpr: Rule1[Foo2]     = rule(foo1 ~ 2.times(foo1 ~> Foo2.apply))
 
-    def foo1 = rule(push(Foo1))
+    def foo1: Rule1[Foo] = rule(push(Foo1))
   }
 
   val tests = Tests {


### PR DESCRIPTION
aside from adding `.apply` to constructors, the most important bit is to
add the type annotation to the `foo1` rule

/cc @yanns 