### PR TITLE
use latest 3.1.1-RC1 snapshot

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbtcrossproject.CrossPlugin.autoImport._
 
 val Scala2_12 = "2.12.14"
 val Scala2_13 = "2.13.6"
-val Scala3    = "3.0.1"
+val Scala3    = "3.1.1-RC1-bin-20211003-6e68045-NIGHTLY"
 
 val isScala3 = Def.setting(
   CrossVersion.partialVersion(scalaVersion.value).exists(_._1 == 3)
@@ -58,7 +58,7 @@ val commonSettings = Seq(
           "-Ybackend-parallelism",
           "8"
         )
-      case Some((3, 0)) =>
+      case Some((3, _)) =>
         Seq("-language:implicitConversions")
       case x => sys.error(s"unsupported scala version: $x")
     }


### PR DESCRIPTION
Fortunately, it seems in the latest Scala 3 nightlies the problems have been fixed and tests that worked with 3.0.1 now work again!

/cc @yanns 