### PR TITLE
Improvements to compilation times on chained subrules

### DIFF
--- a/parboiled-core/src/main/scala-3/org/parboiled2/support/TailSwitch.scala
+++ b/parboiled-core/src/main/scala-3/org/parboiled2/support/TailSwitch.scala
@@ -74,6 +74,12 @@ object TailSwitch {
   type Aux[L <: HList, LI <: HList, T <: HList, TI <: HList, R <: HList, RI <: HList, Out0 <: HList] =
     TailSwitch[L, T, R] { type Out = Out0 }
 
-  implicit def tailSwitch[L <: HList, T <: HList, R <: HList]
+  implicit def tailSwitch[L <: _ :: _, T <: _ :: _, R <: HList]
       : TailSwitch[L, T, R] { type Out = TailSwitch0[L, L, T, T, R, HNil] } = `n/a`
+  /// Optimisations to reduce compilation times to something tolerable
+  implicit def tailSwitch0: TailSwitch[HNil, HNil, HNil] { type Out = HNil }                               = `n/a`
+  implicit def tailSwitch1[T <: _ :: _]: TailSwitch[HNil, T, HNil] { type Out = HNil }                     = `n/a`
+  implicit def tailSwitch2[L <: _ :: _, R <: _ :: _]: TailSwitch[L, HNil, R] { type Out = Prepend0[L, R] } = `n/a`
+  implicit def tailSwitch3[L <: _ :: _]: TailSwitch[L, HNil, HNil] { type Out = L }                        = `n/a`
+  implicit def tailSwitch4[T <: HList, R <: _ :: _]: TailSwitch[HNil, T, R] { type Out = R }               = `n/a`
 }

--- a/parboiled-core/src/test/scala/org/parboiled2/CompileDurationTest.scala
+++ b/parboiled-core/src/test/scala/org/parboiled2/CompileDurationTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2009-2019 Mathias Doenitz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.parboiled2
+
+import utest._
+
+import org.parboiled2.support.hlist.{::, HNil}
+
+object CompileDurationTest extends TestParserSpec {
+
+  val tests = Tests {
+
+    "The Parser should compile" - {
+      def combine6(a1: String, a2: String, a3: String, a4: String, a5: String, a6: String): String =
+        a1 + a2 + a3 + a4 + a5 + a6
+
+      "`~` combinator" - new TestParser1[String] {
+        def basicRule: Rule[HNil, String :: HNil] = rule(capture("a"))
+        def targetRule = rule(
+          basicRule ~ basicRule ~ basicRule ~ basicRule ~ basicRule ~ basicRule ~> combine6 _
+        )
+
+        "" must beMismatched
+        "aaaaaa" must beMatched
+        "ac" must beMismatched
+        "a" must beMismatched
+        "b" must beMismatched
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
cf https://github.com/sirthias/parboiled2/issues/360
- Adds a test that hangs compilation for > 1hr without the optimisations
- Adds a horrible hack that reduces the compilation to something more tolerable

I'm not sure how one would go about writing a test that a piece of code compiles within a certain duration. Have added a pathological test case with which one can observe the speed-up anyway - since it takes so long without, I figured at least it would time-out CI, which is _sort of_ like a proper test. This is _not_ a general-case solution, however for the usages in akka-http it appears to be 'sufficiently good'.

Edit: in light of the recent patches to the scala compiler, this is all probably quite irrelevant now. Will leave the prs open until the release of and migration to 3.1.3 though, unless anyone decides they should be closed earlier.