### PR TITLE
Reuse ValueStack to avoid extra allocations

### DIFF
--- a/parboiled-core/src/main/scala/org/parboiled2/Parser.scala
+++ b/parboiled-core/src/main/scala/org/parboiled2/Parser.scala
@@ -99,14 +99,14 @@ abstract class Parser(initialValueStackSize: Int = 16, maxValueStackSize: Int = 
   // the current ErrorAnalysisPhase or null (in the initial run)
   private var phase: ErrorAnalysisPhase = _
 
-  private var _maxLength = -1
+  private var _inputLength = -1
 
   def copyStateFrom(other: Parser, offset: Int): Unit = {
     _cursorChar = other._cursorChar
     _cursor = other._cursor - offset
     _valueStack = other._valueStack
     phase = other.phase
-    _maxLength = other._maxLength
+    _inputLength = other._inputLength
     if (phase ne null) phase.applyOffset(offset)
   }
 
@@ -119,7 +119,7 @@ abstract class Parser(initialValueStackSize: Int = 16, maxValueStackSize: Int = 
   def __run[L <: HList](rule: => RuleN[L])(implicit scheme: Parser.DeliveryScheme[L]): scheme.Result = {
     def runRule(): Boolean = {
       _cursor = -1
-      _maxLength = input.length
+      _inputLength = input.length
       __advance()
       valueStack.clear()
       try rule ne null
@@ -207,9 +207,9 @@ abstract class Parser(initialValueStackSize: Int = 16, maxValueStackSize: Int = 
     */
   def __advance(): Boolean = {
     val c = _cursor
-    if (c < _maxLength) {
+    if (c < _inputLength) {
       _cursor = c + 1
-      _cursorChar = if ((c + 1) == _maxLength) EOI else input charAt (c + 1)
+      _cursorChar = if ((c + 1) == _inputLength) EOI else input charAt (c + 1)
     }
     true
   }

--- a/parboiled-core/src/main/scala/org/parboiled2/Parser.scala
+++ b/parboiled-core/src/main/scala/org/parboiled2/Parser.scala
@@ -106,7 +106,7 @@ abstract class Parser(initialValueStackSize: Int = 16, maxValueStackSize: Int = 
     _cursor = other._cursor - offset
     _valueStack = other._valueStack
     phase = other.phase
-    _inputLength = other._inputLength
+    _inputLength = other._inputLength - offset
     if (phase ne null) phase.applyOffset(offset)
   }
 

--- a/parboiled-core/src/main/scala/org/parboiled2/Parser.scala
+++ b/parboiled-core/src/main/scala/org/parboiled2/Parser.scala
@@ -94,16 +94,19 @@ abstract class Parser(initialValueStackSize: Int = 16, maxValueStackSize: Int = 
   private var _cursor: Int = _
 
   // the value stack instance we operate on
-  private var _valueStack: ValueStack = _
+  private var _valueStack: ValueStack = new ValueStack(initialValueStackSize, maxValueStackSize)
 
   // the current ErrorAnalysisPhase or null (in the initial run)
   private var phase: ErrorAnalysisPhase = _
+
+  private var _maxLength = -1
 
   def copyStateFrom(other: Parser, offset: Int): Unit = {
     _cursorChar = other._cursorChar
     _cursor = other._cursor - offset
     _valueStack = other._valueStack
     phase = other.phase
+    _maxLength = other._maxLength
     if (phase ne null) phase.applyOffset(offset)
   }
 
@@ -116,6 +119,7 @@ abstract class Parser(initialValueStackSize: Int = 16, maxValueStackSize: Int = 
   def __run[L <: HList](rule: => RuleN[L])(implicit scheme: Parser.DeliveryScheme[L]): scheme.Result = {
     def runRule(): Boolean = {
       _cursor = -1
+      _maxLength = input.length
       __advance()
       valueStack.clear()
       try rule ne null
@@ -124,10 +128,7 @@ abstract class Parser(initialValueStackSize: Int = 16, maxValueStackSize: Int = 
       }
     }
 
-    def phase0_initialRun() = {
-      _valueStack = new ValueStack(initialValueStackSize, maxValueStackSize)
-      runRule()
-    }
+    def phase0_initialRun() = runRule()
 
     def phase1_establishPrincipalErrorIndex(): Int = {
       val phase1 = new EstablishingPrincipalErrorIndex()
@@ -205,12 +206,10 @@ abstract class Parser(initialValueStackSize: Int = 16, maxValueStackSize: Int = 
   /** THIS IS NOT PUBLIC API and might become hidden in future. Use only if you know what you are doing!
     */
   def __advance(): Boolean = {
-    var c   = _cursor
-    val max = input.length
-    if (c < max) {
-      c += 1
-      _cursor = c
-      _cursorChar = if (c == max) EOI else input charAt c
+    val c = _cursor
+    if (c < _maxLength) {
+      _cursor = c + 1
+      _cursorChar = if ((c + 1) == _maxLength) EOI else input charAt (c + 1)
     }
     true
   }


### PR DESCRIPTION
This PR is a performance improvement that Pekko (from fork of Akka) did to their internal parboiled2 which is now being upstreamed (for context see https://github.com/apache/incubator-pekko-http/commit/d3b1322d4526171370935ec7b4648bc45fabc672).

The changes are exactly the same, the only difference is https://github.com/apache/incubator-pekko-http/commit/d3b1322d4526171370935ec7b4648bc45fabc672#diff-f223a66f93d7d04295162c661f633c286badfbb5f1eb1ae293de9c4a19f65f97R95. Not entirely sure why this function was made `final`, my initial suspicions was to prevent overriding (which can hurt performance) and also give the JVM a hint to inline this sooner (at first glance JVM should inline this eventually, the `final` would just make it happen sooner). If changing it to `final def` is necessary it may make sense to do this in a separate PR (in which case everything relevant in `RuleDSLBasics` should be made `final`).

@jrudolph 