### PR TITLE
Don't extend from Char => Boolean for CharPredicate

### DIFF
--- a/parboiled-core/src/main/scala/org/parboiled2/CharPredicate.scala
+++ b/parboiled-core/src/main/scala/org/parboiled2/CharPredicate.scala
@@ -19,8 +19,9 @@ package org.parboiled2
 import scala.annotation.tailrec
 import scala.collection.immutable.NumericRange
 
-sealed abstract class CharPredicate extends (Char => Boolean) {
+sealed abstract class CharPredicate {
   import CharPredicate._
+  def apply(char: Char): Boolean
 
   /** Determines wether this CharPredicate is an instance of the high-performance,
     * constant-time `CharPredicate.MaskBased` implementation.
@@ -88,14 +89,14 @@ sealed abstract class CharPredicate extends (Char => Boolean) {
       case ix => Some(string charAt ix)
     }
 
-  protected def or(that: Char => Boolean): CharPredicate =
-    from(if (this == Empty) that else c => this(c) || that(c))
+  protected def or(that: CharPredicate): CharPredicate =
+    if (this == Empty) that else from(c => this(c) || that(c))
 
-  protected def and(that: Char => Boolean): CharPredicate =
+  protected def and(that: CharPredicate): CharPredicate =
     if (this == Empty) Empty else from(c => this(c) && that(c))
 
-  protected def andNot(that: Char => Boolean): CharPredicate =
-    if (this == Empty) Empty else from(c => this(c) && !that(c))
+  protected def andNot(that: CharPredicate): CharPredicate =
+    if (this == Empty) from(c => !that(c)) else from(c => this(c) && !that(c))
 }
 
 object CharPredicate {
@@ -114,11 +115,7 @@ object CharPredicate {
   val Visible              = CharPredicate('\u0021' to '\u007e')
   val Printable            = Visible ++ ' '
 
-  def from(predicate: Char => Boolean): CharPredicate =
-    predicate match {
-      case x: CharPredicate => x
-      case x                => General(x)
-    }
+  def from(predicate: Char => Boolean): CharPredicate = General(predicate)
 
   def apply(magnets: ApplyMagnet*): CharPredicate = magnets.foldLeft(Empty)((a, m) => a ++ m.predicate)
 
@@ -126,6 +123,7 @@ object CharPredicate {
 
   object ApplyMagnet {
     implicit def fromPredicate(predicate: Char => Boolean): ApplyMagnet = new ApplyMagnet(from(predicate))
+    implicit def fromPredicate(predicate: CharPredicate): ApplyMagnet = new ApplyMagnet(predicate)
     implicit def fromChar(c: Char): ApplyMagnet                         = fromChars(c :: Nil)
     implicit def fromCharArray(array: Array[Char]): ApplyMagnet         = fromChars(array.toIndexedSeq)
     implicit def fromString(chars: String): ApplyMagnet                 = fromChars(chars)
@@ -294,7 +292,7 @@ object CharPredicate {
   }
 
   case class General private[CharPredicate] (predicate: Char => Boolean) extends CharPredicate {
-    def apply(c: Char) = predicate(c)
+    def apply(c: Char): Boolean = predicate(c)
 
     def ++(that: CharPredicate): CharPredicate =
       that match {


### PR DESCRIPTION
This PR is a performance improvement that Pekko (from fork of Akka) did to their internal parboiled2 which is now being upstreamed (for context see https://github.com/apache/incubator-pekko-https://github.com/apache/incubator-pekko-http/commit/1a50f8afd1f21b2c686b8015034a12a1fed47ce1).

The only change that wasn't done was making `CharPredicate` private (which isn't applicable here)

@jrudolph 
