### PR TITLE
Avoid using Scala's Range to reduce allocations

### DIFF
--- a/parboiled-core/src/main/scala/org/parboiled2/CharPredicate.scala
+++ b/parboiled-core/src/main/scala/org/parboiled2/CharPredicate.scala
@@ -102,17 +102,17 @@ sealed abstract class CharPredicate {
 object CharPredicate {
   val Empty: CharPredicate = MaskBased(0L, 0L)
   val All: CharPredicate   = from(_ => true)
-  val LowerAlpha           = CharPredicate('a' to 'z')
-  val UpperAlpha           = CharPredicate('A' to 'Z')
+  val LowerAlpha           = CharPredicate.from(c => c >= 'a' && c <= 'z')
+  val UpperAlpha           = CharPredicate.from(c => c >= 'A' && c <= 'Z')
   val Alpha                = LowerAlpha ++ UpperAlpha
-  val Digit                = CharPredicate('0' to '9')
-  val Digit19              = CharPredicate('1' to '9')
+  val Digit                = CharPredicate.from(c => c >= '0' && c <= '9')
+  val Digit19              = CharPredicate.from(c => c >= '1' && c <= '9')
   val AlphaNum             = Alpha ++ Digit
-  val LowerHexLetter       = CharPredicate('a' to 'f')
-  val UpperHexLetter       = CharPredicate('A' to 'F')
+  val LowerHexLetter       = CharPredicate.from(c => c >= 'a' && c <= 'f')
+  val UpperHexLetter       = CharPredicate.from(c => c >= 'A' && c <= 'F')
   val HexLetter            = LowerHexLetter ++ UpperHexLetter
   val HexDigit             = Digit ++ HexLetter
-  val Visible              = CharPredicate('\u0021' to '\u007e')
+  val Visible              = CharPredicate.from(c => c >= '\u0021' && c <= '\u007e')
   val Printable            = Visible ++ ' '
 
   def from(predicate: Char => Boolean): CharPredicate = General(predicate)


### PR DESCRIPTION
This PR is a performance improvement that Pekko (from fork of Akka) did to their internal parboiled2 which is now being upstreamed (for context see https://github.com/apache/incubator-pekko-http/commit/58d8f48f2bb81f3eedbc743aa890dc8e80da252f).

Note that this version has been changed to be more appropriate for upstreaming, i.e. rather than manually inlining the condition (i.e. https://github.com/apache/incubator-pekko-http/commit/58d8f48f2bb81f3eedbc743aa890dc8e80da252f#diff-403c5e6ae1c63f17319929eff0a1f26e3de854a49308f8a7bd2ec707de395ed0L173) instead I have opted to update the constants in `CharPredicate` directly (furthermore I have done the change to all `CharPredicate`'s).  That means the PR performance for this PR also implies that `CharPredicate.from` ends up getting inlined (needs to be verified?)

@jrudolph