### PR TITLE
Add scalafmt exclude paths for backend target folders

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -6,6 +6,14 @@ fileOverride {
     runner.dialect = scala3
   }
 }
+project.excludePaths = [
+    "glob:/parboiled-core/.js/**",
+    "glob:/parboiled-core/.jvm/**",
+    "glob:/parboiled-core/.native/**",
+    "glob:/parboiled/.js/**",
+    "glob:/parboiled/.jvm/**",
+    "glob:/parboiled/.native/**"
+]
 
 docstrings.style = keep
 


### PR DESCRIPTION
The scalafmtCheckAll on CI is complaining about files in these folders even though they shouldn't be checked