### PR TITLE
Make scalafmt explicit github actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,7 @@ jobs:
     - uses: coursier/cache-action@v6
     - name: ${{ matrix.name }} ${{ matrix.java }}
       run: sbt
-           scalafmtSbtCheck
            "+headerCheckAll"
            "+scalaParser/headerCheckAll"
-           "+scalafmtCheckAll"
-           "+scalaParser/scalafmtCheckAll"
            "+test"
            "+scalaParser/testOnly scalaparser.SnippetSpec"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,23 @@
+name: Scalafmt
+
+permissions: read-all
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    name: Code is formatted
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v2
+        with:
+          version: '3.0.7'

--- a/build.sbt
+++ b/build.sbt
@@ -68,14 +68,7 @@ val commonSettings = Seq(
   Compile / doc / scalacOptions += "-no-link-warnings",
   sourcesInBase := false,
   // file headers
-  headerLicense := Some(HeaderLicense.ALv2("2009-2019", "Mathias Doenitz")),
-  // reformat main and test sources on compile
-  scalafmtOnCompile := true
-)
-
-lazy val crossSettings = Seq(
-  (Compile / scalafmt / sourceDirectories) := (Compile / unmanagedSourceDirectories).value,
-  (Test / scalafmt / sourceDirectories)    := (Test / unmanagedSourceDirectories).value
+  headerLicense := Some(HeaderLicense.ALv2("2009-2019", "Mathias Doenitz"))
 )
 
 lazy val nativeSettings = Seq(


### PR DESCRIPTION
This PR puts scalafmt into its own explicit github workflow, this method of checking if the codebase is formatted has the following advantages

* Since the scalafmt'ing is now its own workflow, it can be added as a github status check to make it impossible to merge PR's that aren't formatted
  * This also means that you can remove the `scalafmtOnCompile` which I personally hate because it always messed up with IDE's/editors (i.e. they complain about a change of whats in memory vs whats formatted on disk)
* The formatter uses scalafmt-native which means its incredibly fast. The github actions pipeline to check if a codebase is formatted typically takes 5-10 seconds, providing very quick feedback to people opening PR's if they forgot to format a codebase
  *  Its also done concurrently to the rest of the build (i.e. compile/test). This also means that unlike now, if the code happens to not compile (but still be formatted) you can tell the difference because its not one entire pipeline
  * With newer versions of scalafmt you can also tell it to only format the files that have been changed according to git (see https://github.com/mdedetrich/incubator-pekko/blob/main/.github/workflows/format.yml#L24). Note that this requires a more recent version of scalafmt to work.
  
Once this PR is changed you can add scalafmt to the github branch status check by going to repo settings -> branches -> branch protection rules (edit master) -> Require status checks to pass before merging (make sure checked) and in the dropdown add "Code is formatted", i.e.

![image](https://user-images.githubusercontent.com/2337269/222952256-33d91f13-8fa5-4bf4-98cd-abb847cfeabf.png)

Note that this will only work once this PR has been merged after some delay as github has to register the github action after it runs.