### PR TITLE
Update scalafmt

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,4 +20,5 @@ jobs:
       - name: Check project is formatted
         uses: jrouly/scalafmt-native-action@v2
         with:
-          version: '3.0.7'
+          version: '3.7.2'
+          arguments: '--list --mode diff-ref=origin/master'

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,11 +1,8 @@
-version = 3.0.7
+version = 3.7.2
 
 runner.dialect = scala213
-fileOverride {
-  "glob:**/src/main/scala-3/**" {
-    runner.dialect = scala3
-  }
-}
+project.layout = standardConvention
+project.git = true
 
 docstrings.style = keep
 

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ val commonSettings = Seq(
     "-feature",
     "-language:_",
     "-unchecked"
-    //"-Ywarn-numeric-widen",
+    // "-Ywarn-numeric-widen",
   ),
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/parboiled-core/src/main/scala-2/org/parboiled2/support/OpTreeContext.scala
+++ b/parboiled-core/src/main/scala-2/org/parboiled2/support/OpTreeContext.scala
@@ -180,10 +180,10 @@ trait OpTreeContext[OpTreeCtx <: ParserMacros.ParserContext] {
 
     def renderInner(wrapped: Boolean): Tree =
       q"""val mark = __saveState; ${ops
-        .map(_.render(wrapped))
-        .reduceLeft((l, r) =>
-          q"val l = $l; if (!l) { __restoreState(mark); $r } else true // work-around for https://issues.scala-lang.org/browse/SI-8657"
-        )}"""
+          .map(_.render(wrapped))
+          .reduceLeft((l, r) =>
+            q"val l = $l; if (!l) { __restoreState(mark); $r } else true // work-around for https://issues.scala-lang.org/browse/SI-8657"
+          )}"""
   }
 
   case class CharMatch(charTree: Tree) extends TerminalOpTree {

--- a/parboiled-core/src/main/scala-3/org/parboiled2/support/OpTreeContext.scala
+++ b/parboiled-core/src/main/scala-3/org/parboiled2/support/OpTreeContext.scala
@@ -36,7 +36,8 @@ class OpTreeContext(parser: Expr[Parser])(using Quotes) {
     def render(wrapped: Boolean): Expr[Boolean] =
       if (wrapped) '{
         val start = $parser.cursor
-        try ${ renderInner('start, wrapped) } catch {
+        try ${ renderInner('start, wrapped) }
+        catch {
           case e: org.parboiled2.Parser#TracingBubbleException => ${ bubbleUp('e, 'start) }
         }
       }
@@ -59,7 +60,8 @@ class OpTreeContext(parser: Expr[Parser])(using Quotes) {
 
     final def render(wrapped: Boolean): Expr[Boolean] =
       if (wrapped) '{
-        try ${ renderInner(wrapped) } catch { case org.parboiled2.Parser.StartTracingException => $bubbleUp }
+        try ${ renderInner(wrapped) }
+        catch { case org.parboiled2.Parser.StartTracingException => $bubbleUp }
       }
       else renderInner(wrapped)
 
@@ -934,7 +936,7 @@ class OpTreeContext(parser: Expr[Parser])(using Quotes) {
           Right(call.asExprOf[Rule[_, _]]),
           Expr(callName(call) getOrElse reportError("Illegal rule call: " + call, call.asExpr))
         )
-      //case _ => Unknown(rule.show, rule.show(using Printer.TreeStructure), outerRule.toString)
+      // case _ => Unknown(rule.show, rule.show(using Printer.TreeStructure), outerRule.toString)
     }
     lazy val allRules = rules0PF.orElse(rules1PF.compose[Expr[Rule[_, _]]] { case x => x.asTerm.underlyingArgument })
     def rec(rule: Term): OpTree = allRules.applyOrElse(

--- a/parboiled-core/src/main/scala/org/parboiled2/support/RunResult.scala
+++ b/parboiled-core/src/main/scala/org/parboiled2/support/RunResult.scala
@@ -31,7 +31,7 @@ object RunResult {
 
   object Aux extends Aux1 {
     implicit def forRule[R <: RuleX]: Aux[R, R] = `n/a`
-    //implicit def forFHList[I <: HList, R, In0 <: HList, Out0 <: HList](implicit x: JA[I, R, In0, Out0]): Aux[I => R, Rule[In0, Out0]] = `n/a`
+    // implicit def forFHList[I <: HList, R, In0 <: HList, Out0 <: HList](implicit x: JA[I, R, In0, Out0]): Aux[I => R, Rule[In0, Out0]] = `n/a`
   }
 
   abstract class Aux1 extends Aux2 {

--- a/parboiled-core/src/test/scala/org/parboiled2/ReductionResetSpec.scala
+++ b/parboiled-core/src/test/scala/org/parboiled2/ReductionResetSpec.scala
@@ -62,19 +62,19 @@ object ReductionResetSpec extends TestParserSpec {
         def targetRule = Alternative
 
         // re-enable after fixing
-        //"123" must beMatchedWith(123)
+        // "123" must beMatchedWith(123)
       }
 
       "reduction reset in `zeroOrMore`" - new ReductionResetParser {
         def targetRule = ZeroOrMore
 
-        //"123" must beMatchedWith(123)
+        // "123" must beMatchedWith(123)
       }
 
       "reduction reset in `oneOrMore`" - new ReductionResetParser {
         def targetRule = OneOrMore
 
-        //"123." must beMatchedWith(123)
+        // "123." must beMatchedWith(123)
       }
     }
   }

--- a/parboiled-core/src/test/scala/org/parboiled2/TestParserSpec.scala
+++ b/parboiled-core/src/test/scala/org/parboiled2/TestParserSpec.scala
@@ -54,7 +54,7 @@ abstract class TestParserSpec extends TestSuite {
     def assertMatchedWith(r: Out)(str: String): Unit = assert(parse(str) == Right(r))
     def assertMismatched(str: String): Unit          = assert(parse(str).isLeft)
 
-    //def beMismatchedWithError(pe: ParseError) = parse(_: String).left.toOption.get === pe
+    // def beMismatchedWithError(pe: ParseError) = parse(_: String).left.toOption.get === pe
     def assertMismatchedWithErrorMsg(expected: String)(str: String): Unit = {
       val actual = parse(str).left.toOption.map(formatError(_, errorFormatter)).get
       val expct  = expected.stripMargin

--- a/project/ActionOpsBoilerplate.scala
+++ b/project/ActionOpsBoilerplate.scala
@@ -126,15 +126,19 @@ object ActionOpsBoilerplate {
 
     s"""
        |  implicit def ops$i[II <: HList, ${`A, ...`(i)}]: ActionOps[II, ${`A ::...`(
-      i
-    )} :: HNil] { type Out = Ops$i[II, ${`A, ...`(
-      i
-    )}] } = `n/a`
+        i
+      )} :: HNil] { type Out = Ops$i[II, ${`A, ...`(
+        i
+      )}] } = `n/a`
        |  sealed trait Ops$i[II <: HList, ${`A, ...`(i)}] {
-       |    def apply[RR](f: () => RR)(implicit j: Join[II, ${`A ::...`(i)} :: HNil, RR], c: FCapture[() => RR]): Rule[j.In, j.Out]
+       |    def apply[RR](f: () => RR)(implicit j: Join[II, ${`A ::...`(
+        i
+      )} :: HNil, RR], c: FCapture[() => RR]): Rule[j.In, j.Out]
        |
        |${(1 to i - 1) map consumeOut mkString "\n"}
-       |    def apply[RR](f: (${`A, ...`(i)}) => RR)(implicit j: Join[II, HNil, RR], c: FCapture[(${`A, ...`(i)}) => RR]): Rule[j.In, j.Out]
+       |    def apply[RR](f: (${`A, ...`(i)}) => RR)(implicit j: Join[II, HNil, RR], c: FCapture[(${`A, ...`(
+        i
+      )}) => RR]): Rule[j.In, j.Out]
        |
        |${(1 to 22 - i) map consumeStack mkString "\n"}
        |  }


### PR DESCRIPTION
So this PR updates scalafmt to the latest version, thankfully the diff is actually really minor (almost all of it is just adding a space after `//` comment). The commit for applying scalafmt also has its own author (`Auto Format`) to help distinguish it from a normal person.

Resolves: https://github.com/sirthias/parboiled2/issues/425

@sirthias @xuwei-k When merging this PR, make sure to either do a merge commit or rebase but not squash. This is because I need the commit hash specifically for `Apply scalafmt` commit for the `.git-ignore-blame-revs` file which will be added in a future PR.