### PR TITLE
Setup release through sbt-github-actions and sbt-ci-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,99 @@ jobs:
 
       - name: Build project
         run: sbt ++${{ matrix.scala }} test 'scalaParser/testOnly scalaparser.SnippetSpec'
+
+      - name: Compress target directories
+        run: tar cf targets.tar examples/target parboiled-core/.native/target target scalaParser/target jsonBenchmark/target parboiled/.js/target parboiled/.native/target parboiled/.jvm/target parboiled-core/.jvm/target parboiled-core/.js/target project/target
+
+      - name: Upload target directories
+        uses: actions/upload-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.scala }}-${{ matrix.java }}
+          path: targets.tar
+
+  publish:
+    name: Publish Artifacts
+    needs: [build]
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master')
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [3.2.2]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Setup Java (temurin@11)
+        if: matrix.java == 'temurin@11'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Cache sbt
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+            ~/AppData/Local/Coursier/Cache/v1
+            ~/Library/Caches/Coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Download target directories (2.12.17)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-2.12.17-${{ matrix.java }}
+
+      - name: Inflate target directories (2.12.17)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (2.13.10)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-2.13.10-${{ matrix.java }}
+
+      - name: Inflate target directories (2.13.10)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.2.2)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.2.2-${{ matrix.java }}
+
+      - name: Inflate target directories (3.2.2)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Publish project
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+        run: sbt ++${{ matrix.scala }} ci-release

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"                  % "2.5.0")
 addSbtPlugin("io.crashbox"        % "sbt-gpg"                       % "0.2.1")
-addSbtPlugin("com.github.sbt"     % "sbt-release"                   % "1.1.0")
+addSbtPlugin("com.github.sbt"     % "sbt-ci-release"                % "1.5.11")
 addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"                  % "3.9.17")
 addSbtPlugin("de.heikoseeberger"  % "sbt-header"                    % "5.9.0")
 addSbtPlugin("io.spray"           % "sbt-boilerplate"               % "0.6.1")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "2.4.2-SNAPSHOT"


### PR DESCRIPTION
This PR sets up the project so that to make a proper release you only need to push a tag (i.e. for the next release you would push a tag named `v2.4.2`) and everything else is handled, i.e. a github action will trigger that will build and publish the entire project using JDK 1.8. Additionally snapshots will also be made whenever a PR is merged to `master`.

One thing that works slightly differently is the `version`. As you may have noticed `version.sbt` is deleted, this is because sbt-ci-release uses [sbt-dynver](https://github.com/sbt/sbt-dynver) to generate the version of the project automatically via git tags. In more detail, if the current git status is as at a tag you will get the full version (i.e. `v2.4.1`) however if your current git status is not at a tag then sbt-dynver will automatically create a snapshot version based on the current git commit hash while using the last git tag as the base version, i.e. here is an example

```
[info] examples / version
[info] 	2.4.1+46-c2978b94-SNAPSHOT
[info] parboiledJVM / version
[info] 	2.4.1+46-c2978b94-SNAPSHOT
[info] jsonBenchmark / Jmh / version
[info] 	1.36
[info] parboiledNative / version
[info] 	2.4.1+46-c2978b94-SNAPSHOT
[info] parboiledCoreJS / version
[info] 	2.4.1+46-c2978b94-SNAPSHOT
[info] parboiledJS / version
[info] 	2.4.1+46-c2978b94-SNAPSHOT
[info] parboiledCoreNative / version
[info] 	2.4.1+46-c2978b94-SNAPSHOT
[info] parboiledCoreJVM / version
[info] 	2.4.1+46-c2978b94-SNAPSHOT
[info] version
[info] 	2.4.1+46-c2978b94-SNAPSHOT
```

The only thing you need to do is to add all of the sonatype/PGP related details as github secrets, see https://github.com/sbt/sbt-ci-release#secrets for a comprehensive guide. If you add the github secrets before merging this PR then you can confirm that release will work as it will trigger a snapshot release.