### PR TITLE
Remove old sbt plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,5 @@
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"                  % "2.5.0")
-addSbtPlugin("io.crashbox"        % "sbt-gpg"                       % "0.2.1")
 addSbtPlugin("com.github.sbt"     % "sbt-ci-release"                % "1.5.11")
-addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"                  % "3.9.17")
 addSbtPlugin("de.heikoseeberger"  % "sbt-header"                    % "5.9.0")
 addSbtPlugin("io.spray"           % "sbt-boilerplate"               % "0.6.1")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.13.0")


### PR DESCRIPTION
I think I found the cause of the publishing problem, we had explicit sbt plugins listed in `project/plugins.sbt`  which was overriding the plugin versions brought by `sbt-ci-release`. In particular sbt-gpg was really ancient and for this reason wasn't setting the `loopback` flag appropriately for gpg causing the `gpg: key XXX: error sending to agent: Inappropriate ioctl for device`. This has since been fixed in newer versions of sbt-gpg. sbt-sonatype is also brought in by sbt-ci-release so no reason to provide it explicitly.

@sirthias 