### PR TITLE
Set version scheme

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ val isScala3 = Def.setting(
   CrossVersion.partialVersion(scalaVersion.value).exists(_._1 == 3)
 )
 
+ThisBuild / versionScheme      := Some("early-semver")
 ThisBuild / scalaVersion       := Scala3
 ThisBuild / crossScalaVersions := Seq(Scala2_12, Scala2_13, Scala3)
 


### PR DESCRIPTION
 I noticed that in the last publish snapshot that we aren't setting `versionScheme`, i.e.

```
[warn] versionScheme setting is empty; set `ThisBuild / versionScheme := Some("early-semver")`, `Some("semver-spec")` or `Some("pvp")`
[warn] so tooling can use it for eviction errors etc - https://www.scala-sbt.org/1.x/docs/Publishing.html
```

I set it to `early-semver` since that is what I believe parboiled2 is intended to follow (from https://www.scala-sbt.org/1.x/docs/Publishing.html#Version+scheme).