### PR TITLE
Add windows-latest to ci matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,16 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         scala: [2.12.17, 2.13.10, 3.2.2]
         java: [temurin@8, temurin@11, temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Ignore line ending differences in git
+        if: contains(runner.os, 'windows')
+        shell: bash
+        run: git config --global core.autocrlf false
+
       - name: Checkout current branch (full)
         uses: actions/checkout@v2
         with:
@@ -66,16 +71,20 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Check that workflows are up to date
+        shell: bash
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
       - name: Header check
-        if: ${{ matrix.java=='temurin@8' && matrix.scala=='2.12.17'}}
+        if: ${{ matrix.java=='temurin@8' && matrix.scala=='2.12.17' && matrix.os=='ubuntu-latest' }}
+        shell: bash
         run: sbt ++${{ matrix.scala }} headerCheckAll scalaParser/headerCheckAll
 
       - name: Build project
+        shell: bash
         run: sbt ++${{ matrix.scala }} test 'scalaParser/testOnly scalaparser.SnippetSpec'
 
       - name: Compress target directories
+        shell: bash
         run: tar cf targets.tar examples/target parboiled-core/.native/target target scalaParser/target jsonBenchmark/target parboiled/.js/target parboiled/.native/target parboiled/.jvm/target parboiled-core/.jvm/target parboiled-core/.js/target project/target
 
       - name: Upload target directories
@@ -95,6 +104,10 @@ jobs:
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Ignore line ending differences in git
+        if: contains(runner.os, 'windows')
+        run: git config --global core.autocrlf false
+
       - name: Checkout current branch (full)
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,13 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
+      - name: Configure pagefile for Windows
+        if: contains(runner.os, 'windows')
+        uses: al-cheb/configure-pagefile-action@v1.3
+        with:
+          minimum-size: 4GB
+          maximum-size: 16GB
+
       - name: Check that workflows are up to date
         shell: bash
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck

--- a/build.sbt
+++ b/build.sbt
@@ -245,16 +245,20 @@ ThisBuild / githubWorkflowPublish := Seq(
 )
 
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8"), JavaSpec.temurin("11"), JavaSpec.temurin("17"))
+ThisBuild / githubWorkflowOSes         := Seq("ubuntu-latest", "windows-latest")
 
 ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(
     List("headerCheckAll", "scalaParser/headerCheckAll"),
     name = Some("Header check"),
     cond = {
-      // Header check only needs to be run for one JVM along with one version of Scala
+      // Header check only needs to be run for one JVM, os along with one version of Scala
       val jVersion = (ThisBuild / githubWorkflowJavaVersions).value.head.render
       val sVersion = (ThisBuild / crossScalaVersions).value.head
-      Some("${{ matrix.java=='" + jVersion + "' && matrix.scala=='" + sVersion + "'}}")
+      val uOs      = (ThisBuild / githubWorkflowOSes).value.find(_.contains("ubuntu")).head
+      Some(
+        "${{ matrix.java=='" + jVersion + "' && matrix.scala=='" + sVersion + "' && matrix.os=='" + uOs + "' }}"
+      )
     }
   ),
   WorkflowStep.Sbt(

--- a/build.sbt
+++ b/build.sbt
@@ -247,6 +247,20 @@ ThisBuild / githubWorkflowPublish := Seq(
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8"), JavaSpec.temurin("11"), JavaSpec.temurin("17"))
 ThisBuild / githubWorkflowOSes         := Seq("ubuntu-latest", "windows-latest")
 
+// Workaround that is necessary for Windows,
+// see https://github.com/scala-native/scala-native/blob/9a185986f10a5e69c32339d5701c1196e9885e17/.github/actions/windows-setup-env/action.yml#L21-L33
+ThisBuild / githubWorkflowBuildPreamble := Seq(
+  WorkflowStep.Use(
+    name = Some("Configure pagefile for Windows"),
+    ref = UseRef.Public("al-cheb", "configure-pagefile-action", "v1.3"),
+    params = Map(
+      "minimum-size" -> "4GB",
+      "maximum-size" -> "16GB"
+    ),
+    cond = Some("contains(runner.os, 'windows')")
+  )
+)
+
 ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(
     List("headerCheckAll", "scalaParser/headerCheckAll"),


### PR DESCRIPTION
This PR adds windows to the ci matrix. I presume that since Parboiled2 is used in some critical Scala OS components, making sure it works on windows is a good idea. On the other hand it does explode the CI matrix a bit, so I understand if you don't want to merge the PR.

Only other additional thing to note is that `githubWorkflowOSes` has no effect on what OS is used to pubish Parboild2, this will always be hardcoded against `ubuntu-latest`.