### PR TITLE
Update to Scala 3.3 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        scala: [2.12.17, 2.13.10, 3.2.2]
+        scala: [2.12.17, 2.13.10, 3.3.0]
         java: [temurin@8, temurin@11, temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -107,7 +107,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.2.2]
+        scala: [3.3.0]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -173,12 +173,12 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.2.2)
+      - name: Download target directories (3.3.0)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-3.2.2-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.3.0-${{ matrix.java }}
 
-      - name: Inflate target directories (3.2.2)
+      - name: Inflate target directories (3.3.0)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtcrossproject.CrossPlugin.autoImport._
 
 val Scala2_12 = "2.12.17"
 val Scala2_13 = "2.13.10"
-val Scala3    = "3.2.2"
+val Scala3    = "3.3.0"
 
 val isScala3 = Def.setting(
   CrossVersion.partialVersion(scalaVersion.value).exists(_._1 == 3)


### PR DESCRIPTION
This is currently a WIP PR to test out if there are any potential issues with Scala 3.3 by using RC3. Once Scala 3.3 is properly released I will update this PR.

Scala 3.3 is a big release since its LTS, which means it will be supported for a long time (critical bugs/security fixes will be backported to the 3.3 branch) so its a good idea to prune out any potential issues before the release is made.