### PR TITLE
Rename root project to parboiled2-root

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,6 +121,9 @@ lazy val root = project
   .aggregate(parboiledCoreJVM, parboiledCoreJS, parboiledCoreNative)
   .settings(commonSettings)
   .settings(publish / skip := true)
+  .settings(
+    name := "parboiled2-root"
+  )
 
 lazy val examples = project
   .enablePlugins(AutomateHeaderPlugin)


### PR DESCRIPTION
This is a quality of life change, currently the name of the root project is just `root` which means when used in IDE's like Intellij its unclear what project you have open (see screenshot)

![image](https://user-images.githubusercontent.com/2337269/232307131-eff3d876-41b0-4974-8a79-6868c4524043.png)

With this change you actually get an idea of what you have open

<img width="272" alt="image" src="https://user-images.githubusercontent.com/2337269/232307208-00381a52-eb11-4b9a-99ce-9069f4097607.png">

Note that this change doesn't effect the project in any meaningful way since the `root` project is not published (i.e. `publish / skip := true`)