### PR TITLE
Add inliner for Scala 2.12/Scala2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,18 @@ val commonSettings = Seq(
       case x => sys.error(s"unsupported scala version: $x")
     }
   },
+  Compile / scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 12)) | Some((2, 13)) =>
+        Seq(
+          "-opt-inline-from:org.parboiled2.**",
+          "-opt:l:inline"
+        )
+      case Some((3, _)) =>
+        Seq.empty // // Optimizer not yet available for Scala3, see https://docs.scala-lang.org/overviews/compiler-options/optimizer.html
+      case x => sys.error(s"unsupported scala version: $x")
+    }
+  },
   Compile / console / scalacOptions ~= (_ filterNot (o => o == "-Ywarn-unused-import" || o == "-Xfatal-warnings")),
   Test / console / scalacOptions ~= (_ filterNot (o => o == "-Ywarn-unused-import" || o == "-Xfatal-warnings")),
   Compile / doc / scalacOptions += "-no-link-warnings",


### PR DESCRIPTION
This PR adds the inliner for Scala 2.12/Scala 2.13. Although in its earlier years the Scala inliner got a bad name/reputation, the current/improved Scala inliner which is found in the later versions of Scala 2.12/2.13 is considered much more comprehensive and importantly safe. As an example it will actually warn if you happen to use the `@inline` annotation and it fails to inline a statement. wrt to the statement about safety, the inliner is safe enough that it is enabled by default for scala modules (see https://github.com/scala/sbt-scala-module/blob/main/src/main/scala/ScalaModulePlugin.scala#L51-L60).

While ordinarily you would use `-opt-inline-from:<sources>` since its whats recommended for libraries, from https://docs.scala-lang.org/overviews/compiler-options/optimizer.html

> `-opt:inline:<sources>`, where the pattern is the literal string `<sources>`, enables inlining from the set of source files being compiled in the current compiler invocation. This option can also be used for compiling libraries. If the source files of a library are split up across multiple sbt projects, inlining is only done within each project. Note that in an incremental compilation, inlining would only happen within the sources being re-compiled – but in any case, it is recommended to only enable the optimizer in CI and release builds (and to run `clean` before building).

I instead opted to use `-opt-inline-from:org.parboiled2.**` since the `parboiled-core` package isn't actually published as an artifact. This allows the inliner to work freely to inline anything from both `parboiled` and `parboiled-core` sbt projects as long as they are within the `org.parboiled2` package which is safe since they only create one artifact.

In regards to how the new inliner actually works, you can read https://docs.scala-lang.org/overviews/compiler-options/optimizer.html but the tl;dr is that it does its best to make sure it can produce code that the hotspot JVM can inline rather than just blindly inlining stuff (for example it targets pathological cases such as megamorphic dispatch). If you want to force inlining of certain statements let me know and I can add `@inline` annotation to them, note that the `@inline` annotation doesn't actually do anything unless you enable the inliner which is what this PR does.