### PR TITLE
Setup publishing with sonatype bundle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,7 @@ lazy val publishingSettings = Seq(
   publishMavenStyle         := true,
   Test / publishArtifact    := false,
   pomIncludeRepository      := (_ => false),
-  publishTo                 := sonatypePublishTo.value,
+  publishTo                 := sonatypePublishToBundle.value,
   publishConfiguration      := publishConfiguration.value.withOverwrite(true),
   publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(true),
   developers := List(


### PR DESCRIPTION
The newer versions of sonatype use bundle deployments which needs to be setup (see https://github.com/xerial/sbt-sonatype/issues/103#issuecomment-530160058).

A quick explanation of bundle deployments is that they are atomic, i.e. you first upload the entire package (which can contain multiple artifacts/jars) and then you deploy that package all at once.

This is only done for non snapshot releases which is why we didn't get a problem earlier.

@sirthias 