### PR TITLE
Add Automatic-Module-Name attribute to JVM distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ buck-out/
 
 ########### Bundle artifact ###########
 *.jsbundle
+
+########### Intellij ###########
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -200,7 +200,8 @@ lazy val parboiled = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .jvmSettings(
     (Compile / packageBin / mappings) ++= (parboiledCoreJVM.project / Compile / packageBin / mappings).value,
     (Compile / packageSrc / mappings) ++= (parboiledCoreJVM.project / Compile / packageSrc / mappings).value,
-    (Compile / packageDoc / mappings) ++= (parboiledCoreJVM.project / Compile / packageDoc / mappings).value
+    (Compile / packageDoc / mappings) ++= (parboiledCoreJVM.project / Compile / packageDoc / mappings).value,
+    (Compile / packageBin / packageOptions) += Package.ManifestAttributes("Automatic-Module-Name" -> "org.parboiled2.parboiled")
   )
   .jsSettings(
     (Compile / packageBin / mappings) ++= (parboiledCoreJS.project / Compile / packageBin / mappings).value,


### PR DESCRIPTION
This is my first time working with sbt and  I'm not sure if I did the right things. 
I followed the approach used by scala: https://github.com/scala/scala/commit/dd1631348ddf17ae74b9759dd674ef1b80f54ecb

I'm not sure if the module name is appropriate and if we should provide a module name for the native and the js distribution also.